### PR TITLE
hotfix: replace back-button icon

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -27,9 +27,11 @@ import {
   SiVisualstudiocode,
   SiWordpress,
 } from 'react-icons/si';
-import { RxLaptop, RxMoon, RxSun } from 'react-icons/rx';
+import { RxChevronLeft, RxChevronRight, RxLaptop, RxMoon, RxSun } from 'react-icons/rx';
 
 export const Icons = {
+  Left: RxChevronLeft,
+  Right: RxChevronRight,
   Laptop: RxLaptop,
   Moon: RxMoon,
   Sun: RxSun,

--- a/src/components/ui/Button/BackButton.tsx
+++ b/src/components/ui/Button/BackButton.tsx
@@ -18,7 +18,7 @@ const BackButton: FC<BackButtonProps> = ({ className, ...props }) => {
       className={cn('w-fit', className)}
     >
       <>
-        <Icons.ChevronLeft className='mr-2 h-4 w-4' />
+        <Icons.Left className='mr-2 h-4 w-4' />
         Back
       </>
     </Button>


### PR DESCRIPTION
....missed an error on vercel deployment

This adds ChevronLeft and ChevronRight icons so that the left one can be used for the back button